### PR TITLE
[Feature] 🌎 Country and 🔝 Races Count selection filters via menu options

### DIFF
--- a/DomainLayer/Sources/DomainLayer/NextRacesInteracting.swift
+++ b/DomainLayer/Sources/DomainLayer/NextRacesInteracting.swift
@@ -17,7 +17,8 @@ public protocol NextRacesInteracting: AnyObject {
     /// - Parameters:
     ///   - categories: The array of categories (of races) to find.
     ///   - count: The  number of races to find based on the categories provided.
-    ///   - tolerance: The optional hard tolerance (in time interval seconds)  to 100% remove any race which are beyond past this (in negative)
+    ///   - tolerance: The optional hard tolerance (in time interval seconds)  to 100%
+    ///   remove any race which are beyond past this (in negative) value.
     /// - Returns: A publisher that repeatedly emits the found races.
     ///
     func nextRaces(

--- a/DomainLayer/Sources/DomainLayer/NextRacesInteracting.swift
+++ b/DomainLayer/Sources/DomainLayer/NextRacesInteracting.swift
@@ -10,19 +10,22 @@ public protocol NextRacesInteracting: AnyObject {
 
     ///
     /// Gets the latest next x number races live and poll through it.
-    /// ‼️ This publisher would create a continuous subscription that would
-    /// never stop emitting as long as it being subscribed and not being
-    /// cancelled by the consumer. This would poll through the next possible
-    /// x number of races to fetch the data  and re-publish the fetched results. ‼️
+    /// ‼️ This publisher would create a continuous subscription that would  never stop emitting
+    /// as long as it being subscribed and not being cancelled by the consumer. This would poll
+    /// through the next possible x number of races to fetch the data  and re-publish the fetched results. ‼️
     /// - Parameters:
-    ///   - categories: The array of categories (of races) to find.
-    ///   - count: The  number of races to find based on the categories provided.
-    ///   - tolerance: The optional hard tolerance (in time interval seconds)  to 100%
-    ///   remove any race which are beyond past this (in negative) value.
-    /// - Returns: A publisher that repeatedly emits the found races.
+    ///   - categories: The array of categories (of races) to find latest races happening.
+    ///   - country: The specific country (3 letter alpha code) of interest to filter races.
+    ///   Pass `nil` to not filter any, means the outcome is international.
+    ///   - count: The number of races to return based on the categories provided.
+    ///   This is used to configure the desired number of top races from the list.
+    ///   - tolerance: The optional hard tolerance (in time interval seconds)  to 100% remove
+    ///   any races which are beyond past this (in negative) value.
+    /// - Returns: A publisher that repeatedly emits the latest races reactively.
     ///
     func nextRaces(
-        for categories: [Race.Category],
+        forCategories categories: [Race.Category],
+        andCountry country: String?,
         numberOfRaces count: Int,
         hardNegativeTolerance tolerance: TimeInterval?
     ) -> AnyPublisher<[Race], DataLayer.NetworkError>

--- a/DomainLayer/Sources/DomainLayer/NextRacesIntercator.swift
+++ b/DomainLayer/Sources/DomainLayer/NextRacesIntercator.swift
@@ -29,14 +29,17 @@ public final class NextRacesInteractor: NextRacesInteracting {
     // MARK: - NextRacesInteracting
 
     public func nextRaces(
-        for categories: [Race.Category],
+        forCategories categories: [Race.Category],
+        andCountry country: String?,
         numberOfRaces count: Int,
-        hardNegativeTolerance tolerance: TimeInterval? = nil
+        hardNegativeTolerance tolerance: TimeInterval?
     ) -> AnyPublisher<[Race], DataLayer.NetworkError> {
 
+        print(country ?? "*******")
+
         // 🤚🏽🤚🏽
-        // Always try to load 50 races at once, but then later filter out based
-        // on the exact need by category and number of races to show on UI.
+        // Always try to load 50 races at once, but then later on filter out
+        // based on the exact need by category and number of races to show on UI.
 
         // Perhaps not the best practice to load such heavy volume of data
         // in REST JSON api pattern. GraphQL comes handy here to filter out
@@ -105,6 +108,10 @@ public final class NextRacesInteractor: NextRacesInteracting {
                                 return timeLeft > tolerance
                             }
                             .sorted {  $0.startTime <= $1.startTime }
+                            .filter { race in
+                                guard let country else { return true }
+                                return race.venu.country == country
+                            }
                             .prefix(count)
 
                         return Array(sortedTopRaces)

--- a/DomainLayer/Sources/DomainLayer/NextRacesIntercator.swift
+++ b/DomainLayer/Sources/DomainLayer/NextRacesIntercator.swift
@@ -35,8 +35,6 @@ public final class NextRacesInteractor: NextRacesInteracting {
         hardNegativeTolerance tolerance: TimeInterval?
     ) -> AnyPublisher<[Race], DataLayer.NetworkError> {
 
-        print(country ?? "*******")
-
         // 🤚🏽🤚🏽
         // Always try to load 50 races at once, but then later on filter out
         // based on the exact need by category and number of races to show on UI.

--- a/DomainLayer/Sources/DomainLayer/TestHelpers/NextRacesInteractor+TestDoubles.swift
+++ b/DomainLayer/Sources/DomainLayer/TestHelpers/NextRacesInteractor+TestDoubles.swift
@@ -14,13 +14,24 @@ public final class NextRacesInteractorSpy: NextRacesInteracting {
     // Spied calls
     public var nextRacesCalled: Bool = false
 
+    // Spied values
+    public var categories: [Race.Category] = []
+    public var country: String?
+    public var racesCount: Int = 0
+
     public func nextRaces(
         forCategories categories: [Race.Category],
         andCountry country: String?,
         numberOfRaces count: Int,
         hardNegativeTolerance tolerance: TimeInterval? = nil
     ) -> AnyPublisher<[Race], DataLayer.NetworkError> {
+
         nextRacesCalled = true
+
+        self.categories = categories
+        self.country = country
+        self.racesCount = count
+
         return .just([]).eraseToAnyPublisher()
     }
 }

--- a/DomainLayer/Sources/DomainLayer/TestHelpers/NextRacesInteractor+TestDoubles.swift
+++ b/DomainLayer/Sources/DomainLayer/TestHelpers/NextRacesInteractor+TestDoubles.swift
@@ -15,7 +15,8 @@ public final class NextRacesInteractorSpy: NextRacesInteracting {
     public var nextRacesCalled: Bool = false
 
     public func nextRaces(
-        for categories: [Race.Category],
+        forCategories categories: [Race.Category],
+        andCountry country: String?,
         numberOfRaces count: Int,
         hardNegativeTolerance tolerance: TimeInterval? = nil
     ) -> AnyPublisher<[Race], DataLayer.NetworkError> {
@@ -43,7 +44,8 @@ public final class NextRacesInteractorMock: NextRacesInteracting {
     }
 
     public func nextRaces(
-        for categories: [Race.Category],
+        forCategories categories: [Race.Category],
+        andCountry country: String?,
         numberOfRaces count: Int,
         hardNegativeTolerance tolerance: TimeInterval? = nil
     ) -> AnyPublisher<[Race], DataLayer.NetworkError> {

--- a/DomainLayer/Tests/DomainLayerTests/NextRacesInteractorTests.swift
+++ b/DomainLayer/Tests/DomainLayerTests/NextRacesInteractorTests.swift
@@ -45,7 +45,10 @@ final class NextRacesInteractorTests: XCTestCase {
 
         // WHEN - being requested to load races
         interactor.nextRaces(
-            for: [.horse, .greyhound, .harness], numberOfRaces: 20, hardNegativeTolerance: nil
+            forCategories: [.horse, .greyhound, .harness],
+            andCountry: nil,
+            numberOfRaces: 20,
+            hardNegativeTolerance: nil
         )
         .sink { _ in } receiveValue: { _ in
         }.store(in: &cancellables)
@@ -84,7 +87,12 @@ final class NextRacesInteractorTests: XCTestCase {
         interactor = NextRacesInteractor(networkService: serviceMock)
 
         // WHEN - being requested to load 3 races for `horse`
-        interactor.nextRaces(for: [.horse], numberOfRaces: 3, hardNegativeTolerance: nil)
+        interactor.nextRaces(
+            forCategories: [.horse],
+            andCountry: nil,
+            numberOfRaces: 3,
+            hardNegativeTolerance: nil
+        )
             .sink { completion in
                 if case .failure(let error) = completion {
                     receivedError = error
@@ -130,7 +138,12 @@ final class NextRacesInteractorTests: XCTestCase {
         interactor = NextRacesInteractor(networkService: serviceMock)
 
         // WHEN - being requested to load 5 races for `greyhound`
-        interactor.nextRaces(for: [.greyhound], numberOfRaces: 5, hardNegativeTolerance: nil)
+        interactor.nextRaces(
+            forCategories: [.greyhound],
+            andCountry: nil,
+            numberOfRaces: 5,
+            hardNegativeTolerance: nil
+        )
             .sink { completion in
                 if case .failure(let error) = completion {
                     receivedError = error
@@ -170,7 +183,12 @@ final class NextRacesInteractorTests: XCTestCase {
         interactor = NextRacesInteractor(networkService: serviceMock)
 
         // WHEN - being requested to load 5 races for `greyhound` & `harness`
-        interactor.nextRaces(for: [.greyhound, .harness], numberOfRaces: 5, hardNegativeTolerance: nil)
+        interactor.nextRaces(
+            forCategories: [.greyhound, .harness],
+            andCountry: nil,
+            numberOfRaces: 3,
+            hardNegativeTolerance: nil
+        )
             .sink { completion in
                 if case .failure(let error) = completion {
                     receivedError = error
@@ -215,7 +233,12 @@ final class NextRacesInteractorTests: XCTestCase {
         interactor = NextRacesInteractor(networkService: serviceMock)
 
         // WHEN - being requested to load 5 races combining all three categories
-        interactor.nextRaces(for: [.horse, .greyhound, .harness], numberOfRaces: 5, hardNegativeTolerance: nil)
+        interactor.nextRaces(
+            forCategories: [.horse, .greyhound, .harness],
+            andCountry: nil,
+            numberOfRaces: 5,
+            hardNegativeTolerance: nil
+        )
             .sink { completion in
                 if case .failure(let error) = completion {
                     receivedError = error

--- a/DomainLayer/Tests/DomainLayerTests/NextRacesInteractorTests.swift
+++ b/DomainLayer/Tests/DomainLayerTests/NextRacesInteractorTests.swift
@@ -3,7 +3,7 @@ import Combine
 @testable import DataLayer
 @testable import DomainLayer
 
-// swiftlint:disable force_unwrapping
+// swiftlint:disable force_unwrapping file_length
 final class NextRacesInteractorTests: XCTestCase {
 
     private var interactor: NextRacesInteracting!
@@ -77,7 +77,9 @@ final class NextRacesInteractorTests: XCTestCase {
         XCTAssertEqual(serviceSpy.parameters?.last?.1.description, "50")
     }
 
-    func testLoadingWithHoseFilterOnly() throws {
+    // MARK: - Race category filers
+
+    func testLoadingWithHorseFilterOnly() throws {
 
         var receivedError: NetworkError?
         var receivedResponse: [Race]?
@@ -182,11 +184,11 @@ final class NextRacesInteractorTests: XCTestCase {
         let serviceMock = NetworkServiceMock(response: TestHelper.sampleRacesList, returningError: false)
         interactor = NextRacesInteractor(networkService: serviceMock)
 
-        // WHEN - being requested to load 5 races for `greyhound` & `harness`
+        // WHEN - being requested to load races for `greyhound` & `harness`
         interactor.nextRaces(
             forCategories: [.greyhound, .harness],
             andCountry: nil,
-            numberOfRaces: 3,
+            numberOfRaces: 5,
             hardNegativeTolerance: nil
         )
             .sink { completion in
@@ -232,7 +234,7 @@ final class NextRacesInteractorTests: XCTestCase {
         let serviceMock = NetworkServiceMock(response: TestHelper.sampleRacesList, returningError: false)
         interactor = NextRacesInteractor(networkService: serviceMock)
 
-        // WHEN - being requested to load 5 races combining all three categories
+        // WHEN - being requested to load races combining all three categories
         interactor.nextRaces(
             forCategories: [.horse, .greyhound, .harness],
             andCountry: nil,
@@ -287,5 +289,237 @@ final class NextRacesInteractorTests: XCTestCase {
         XCTAssertNil(receivedError)
     }
 
+    // MARK: - Country selection filter
+
+    func testCountryFilterUSA() {
+
+        var receivedError: NetworkError?
+        var receivedResponse: [Race]?
+
+        // GIVEN - the interactor is made out of service mock that returns sample races
+        let serviceMock = NetworkServiceMock(response: TestHelper.sampleRacesList, returningError: false)
+        interactor = NextRacesInteractor(networkService: serviceMock)
+
+        // WHEN - being requested to load races across all categories but for "USA" only
+        interactor.nextRaces(
+            forCategories: [.horse, .greyhound, .harness],
+            andCountry: "USA",
+            numberOfRaces: 20,
+            hardNegativeTolerance: nil
+        )
+            .sink { completion in
+                if case .failure(let error) = completion {
+                    receivedError = error
+                }
+            } receiveValue: { response in
+                receivedResponse = response
+            }
+            .store(in: &cancellables)
+
+        // THEN - received race response should be correct with filtered "USA" results.
+
+        XCTAssertEqual(receivedResponse?.count, 3)
+
+        XCTAssertEqual(receivedResponse?[0].category, .horse)
+        XCTAssertEqual(receivedResponse?[0].name, "Race 6 - Claiming")
+        XCTAssertEqual(receivedResponse?[0].venu.country, "USA")
+
+        XCTAssertEqual(receivedResponse?[1].category, .horse)
+        XCTAssertEqual(receivedResponse?[1].name, "Race 3 - Trials")
+        XCTAssertEqual(receivedResponse?[1].venu.country, "USA")
+
+        XCTAssertEqual(receivedResponse?[2].category, .harness)
+        XCTAssertEqual(receivedResponse?[2].name, "Race 7 - 1609M")
+        XCTAssertEqual(receivedResponse?[2].venu.country, "USA")
+
+        // AND - the races are sorted
+
+        XCTAssertTrue(
+            receivedResponse![0].startTime.timeIntervalSince1970 < receivedResponse![1].startTime.timeIntervalSince1970
+        )
+
+        XCTAssertTrue(
+            receivedResponse![1].startTime.timeIntervalSince1970 < receivedResponse![2].startTime.timeIntervalSince1970
+        )
+
+        // AND - there should not any error returned
+        XCTAssertNil(receivedError)
+    }
+
+    func testCountryFilterArgentina() {
+
+        var receivedError: NetworkError?
+        var receivedResponse: [Race]?
+
+        // GIVEN - the interactor is made out of service mock that returns sample races
+        let serviceMock = NetworkServiceMock(response: TestHelper.sampleRacesList, returningError: false)
+        interactor = NextRacesInteractor(networkService: serviceMock)
+
+        // WHEN - being requested to load races for "Argentina" only
+        interactor.nextRaces(
+            forCategories: [.horse, .greyhound],
+            andCountry: "ARG",
+            numberOfRaces: 5,
+            hardNegativeTolerance: nil
+        )
+            .sink { completion in
+                if case .failure(let error) = completion {
+                    receivedError = error
+                }
+            } receiveValue: { response in
+                receivedResponse = response
+            }
+            .store(in: &cancellables)
+
+        // THEN - received race response should be correct with filtered ARG results.
+
+        XCTAssertEqual(receivedResponse?.count, 1)
+
+        XCTAssertEqual(receivedResponse?[0].category, .horse)
+        XCTAssertEqual(receivedResponse?[0].name, "1M Stakes")
+        XCTAssertEqual(receivedResponse?[0].venu.country, "ARG")
+
+        // AND - there should not any error returned
+        XCTAssertNil(receivedError)
+    }
+
+    // MARK: - Top number of required races
+
+    func testTopThreeRaces() {
+
+        var receivedError: NetworkError?
+        var receivedResponse: [Race]?
+
+        // GIVEN - the interactor is made out of service mock that returns sample races
+        let serviceMock = NetworkServiceMock(response: TestHelper.sampleRacesList, returningError: false)
+        interactor = NextRacesInteractor(networkService: serviceMock)
+
+        // WHEN - being requested to load top 3 races only
+        interactor.nextRaces(
+            forCategories: [.horse, .greyhound, .harness],
+            andCountry: nil,  // internationally
+            numberOfRaces: 3, // 3 top races
+            hardNegativeTolerance: nil
+        )
+            .sink { completion in
+                if case .failure(let error) = completion {
+                    receivedError = error
+                }
+            } receiveValue: { response in
+                receivedResponse = response
+            }
+            .store(in: &cancellables)
+
+        // THEN - received race response should be correct with top-3 races only
+
+        XCTAssertEqual(receivedResponse?.count, 3)
+
+        XCTAssertEqual(receivedResponse?[0].category, .horse)
+        XCTAssertEqual(receivedResponse?[0].name, "1M Stakes")
+        XCTAssertEqual(receivedResponse?[0].venu.country, "ARG")
+
+        XCTAssertEqual(receivedResponse?[1].category, .horse)
+        XCTAssertEqual(receivedResponse?[1].name, "Race 6 - Claiming")
+        XCTAssertEqual(receivedResponse?[1].venu.country, "USA")
+
+        XCTAssertEqual(receivedResponse?[2].category, .horse)
+        XCTAssertEqual(receivedResponse?[2].name, "Race 2 - Premio Aiortrophe - 1999")
+        XCTAssertEqual(receivedResponse?[2].venu.country, "BRA")
+
+        // AND - the races are sorted
+
+        XCTAssertTrue(
+            receivedResponse![0].startTime.timeIntervalSince1970 < receivedResponse![1].startTime.timeIntervalSince1970
+        )
+
+        XCTAssertTrue(
+            receivedResponse![1].startTime.timeIntervalSince1970 < receivedResponse![2].startTime.timeIntervalSince1970
+        )
+
+        // AND - there should not any error returned
+        XCTAssertNil(receivedError)
+    }
+
+    // swiftlint:disable:next function_body_length
+    func testTopFiftyRaces() {
+
+        var receivedError: NetworkError?
+        var receivedResponse: [Race]?
+
+        // GIVEN - the interactor is made out of service mock that returns sample races
+        let serviceMock = NetworkServiceMock(response: TestHelper.sampleRacesList, returningError: false)
+        interactor = NextRacesInteractor(networkService: serviceMock)
+
+        // WHEN - being requested to load top Fifty races only
+        interactor.nextRaces(
+            forCategories: [.horse, .greyhound, .harness],
+            andCountry: nil,  // internationally
+            numberOfRaces: 50, // 10 top races
+            hardNegativeTolerance: nil
+        )
+            .sink { completion in
+                if case .failure(let error) = completion {
+                    receivedError = error
+                }
+            } receiveValue: { response in
+                receivedResponse = response
+            }
+            .store(in: &cancellables)
+
+        // THEN - received race response should be correct with max possible
+        // 6 races found
+
+        XCTAssertEqual(receivedResponse?.count, 6)
+
+        XCTAssertEqual(receivedResponse?[0].category, .horse)
+        XCTAssertEqual(receivedResponse?[0].name, "1M Stakes")
+        XCTAssertEqual(receivedResponse?[0].venu.country, "ARG")
+
+        XCTAssertEqual(receivedResponse?[1].category, .horse)
+        XCTAssertEqual(receivedResponse?[1].name, "Race 6 - Claiming")
+        XCTAssertEqual(receivedResponse?[1].venu.country, "USA")
+
+        XCTAssertEqual(receivedResponse?[2].category, .horse)
+        XCTAssertEqual(receivedResponse?[2].name, "Race 2 - Premio Aiortrophe - 1999")
+        XCTAssertEqual(receivedResponse?[2].venu.country, "BRA")
+
+        XCTAssertEqual(receivedResponse?[3].category, .horse)
+        XCTAssertEqual(receivedResponse?[3].name, "Race 3 - Trials")
+        XCTAssertEqual(receivedResponse?[3].venu.country, "USA")
+
+        XCTAssertEqual(receivedResponse?[4].category, .harness)
+        XCTAssertEqual(receivedResponse?[4].name, "Race 7 - 1609M")
+        XCTAssertEqual(receivedResponse?[4].venu.country, "USA")
+
+        XCTAssertEqual(receivedResponse?[5].category, .greyhound)
+        XCTAssertEqual(receivedResponse?[5].name, "Red Snapper Seafoods, Christchurch C0")
+        XCTAssertEqual(receivedResponse?[5].venu.country, "NZ")
+
+        // AND - the races are sorted
+
+        XCTAssertTrue(
+            receivedResponse![0].startTime.timeIntervalSince1970 < receivedResponse![1].startTime.timeIntervalSince1970
+        )
+
+        XCTAssertTrue(
+            receivedResponse![1].startTime.timeIntervalSince1970 < receivedResponse![2].startTime.timeIntervalSince1970
+        )
+
+        XCTAssertTrue(
+            receivedResponse![2].startTime.timeIntervalSince1970 < receivedResponse![3].startTime.timeIntervalSince1970
+        )
+
+        XCTAssertTrue(
+            receivedResponse![3].startTime.timeIntervalSince1970 < receivedResponse![4].startTime.timeIntervalSince1970
+        )
+
+        XCTAssertTrue(
+            receivedResponse![4].startTime.timeIntervalSince1970 < receivedResponse![5].startTime.timeIntervalSince1970
+        )
+
+        // AND - there should not any error returned
+        XCTAssertNil(receivedError)
+    }
+
 }
-// swiftlint:enable force_unwrapping
+// swiftlint:enable force_unwrapping file_length

--- a/NextToGo/en.lproj/Localizable.strings
+++ b/NextToGo/en.lproj/Localizable.strings
@@ -7,10 +7,10 @@
 // English language
 
 // MARK: - Races list
-"next.togo.races.title" = "Next To Go";
+"next.togo.races.title" = "Next to Go";
 
-"next.togo.races.refresh.button.title" = "Refresh";
-"next.togo.races.refresh.button.accessibility.hint" = "Double tap to see most up to date races";
+"next.togo.races.reset.filters.button.title" = "Reset filters";
+"next.togo.races.reset.filters.button.accessibility.hint" = "Double tap to reset all filters and see the latest races";
 
 "next.togo.races.settings.button.title" = "Settings";
 "next.togo.races.settings.button.accessibility.hint" = "Double tap to go to settings";

--- a/NextToGo/fr.lproj/Localizable.strings
+++ b/NextToGo/fr.lproj/Localizable.strings
@@ -9,11 +9,11 @@
 // TODO: ‼️‼️‼️ Translate into French 🇫🇷 ‼️‼️‼️
 // Else French men would hate English 🤣
 
-/// MARK: - Races list
-"next.togo.races.title" = "Next To Go";
+// MARK: - Races list
+"next.togo.races.title" = "Next to Go";
 
-"next.togo.races.refresh.button.title" = "Refresh";
-"next.togo.races.refresh.button.accessibility.hint" = "Double tap to see most up to date races";
+"next.togo.races.reset.filters.button.title" = "Refresh";
+"next.togo.races.reset.filters.button.accessibility.hint" = "Double tap to see most up to date races";
 
 "next.togo.races.settings.button.title" = "Settings";
 "next.togo.races.settings.button.accessibility.hint" = "Double tap to go to settings";
@@ -34,6 +34,9 @@
 "next.togo.races.error.generic.message" = "Please try again soon and start punting.";
 "next.togo.races.error.network.heading" = "You seem to be offline!";
 "next.togo.races.error.network.message" = "Please connect to the Internet and start punting.";
+
+"next.togo.races.empty.title" = "Uh-oh! There aren't any races.";
+"next.togo.races.empty.message" = "Races would be available soon. Please check in a while and start punting.";
 
 "next.togo.races.empty.title" = "Uh-oh! There aren't any races.";
 "next.togo.races.empty.message" = "Races would be available soon. Please check in a while and start punting.";

--- a/NextToGo/ja.lproj/Localizable.strings
+++ b/NextToGo/ja.lproj/Localizable.strings
@@ -8,11 +8,11 @@
 
 // TODO: ‼️‼️‼️ Translate into Japanese 🇯🇵 ‼️‼️‼️
 
-/// MARK: - Races list
-"next.togo.races.title" = "Next To Go";
+// MARK: - Races list
+"next.togo.races.title" = "Next to Go";
 
-"next.togo.races.refresh.button.title" = "Refresh";
-"next.togo.races.refresh.button.accessibility.hint" = "Double tap to see most up to date races";
+"next.togo.races.reset.filters.button.title" = "Refresh";
+"next.togo.races.reset.filters.button.accessibility.hint" = "Double tap to see most up to date races";
 
 "next.togo.races.settings.button.title" = "Settings";
 "next.togo.races.settings.button.accessibility.hint" = "Double tap to go to settings";

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoView.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoView.swift
@@ -19,6 +19,8 @@ public struct NextToGoView: View {
 
     @AppStorage("isDarkMode") private var isDarkMode = false
 
+    @Environment(\.sizeCategory) private var sizeCategory
+
     private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Initializer
@@ -101,11 +103,23 @@ private extension NextToGoView {
         }
 
         ToolbarItem(placement: .principal) {
-            Image(systemName: viewModel.navBarHeroIcon)
-                .resizable()
-                .frame(width: 36, height: 36)
-                .foregroundColor(.red)
-                .accessibilityHidden(true)
+            HStack(spacing: 10) {
+                Text(viewModel.title)
+                    .font(.title3)
+                    .fontWeight(.medium)
+                    .foregroundColor(.primary)
+                    .multilineTextAlignment(.leading)
+
+                Image(systemName: viewModel.navBarHeroIcon)
+                    .resizable()
+                    .scaledToFit()
+                    .font(.system(size: 20, weight: .medium, design: .rounded))
+                    .frame(width: 30, height: 30)
+                    .foregroundColor(.red)
+                    .accessibilityHidden(true)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityAddTraits(.isHeader)
         }
 
         ToolbarItem(placement: .navigationBarTrailing) {
@@ -131,19 +145,10 @@ private extension NextToGoView {
 
     @ViewBuilder
     var headingStack: some View {
-        VStack(alignment: .leading) {
-            Text(viewModel.title)
-                .font(.title2)
-                .fontWeight(.medium)
-                .foregroundColor(.primary)
-                .multilineTextAlignment(.leading)
-                .accessibilityAddTraits(.isHeader)
-
-            HStack(spacing: 16) {
-                Spacer()
-                topCountSelectionMenu
-                countrySelectionMenu
-            }
+        HStack(spacing: 16) {
+            Spacer()
+            topCountSelectionMenu
+            countrySelectionMenu
         }
     }
 
@@ -181,11 +186,11 @@ private extension NextToGoView {
     func menuLabel(from title: String) -> some View {
         HStack(spacing: 0) {
             Text(title)
-                .font(.body)
             Spacer().frame(width: 10)
             Image(systemName: "chevron.up.chevron.down")
-                .font(.body)
         }
+        .font(sizeCategory >= .extraLarge ? .caption : .body)
+        .minimumScaleFactor(0.3)
         .foregroundColor(.red)
         .onTapGesture {
             let haptic = UIImpactFeedbackGenerator(style: .medium)

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoView.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoView.swift
@@ -186,11 +186,22 @@ private extension NextToGoView {
     func menuLabel(from title: String) -> some View {
         HStack(spacing: 0) {
             Text(title)
+                .lineLimit(1)
+                .font(
+                    sizeCategory >= .accessibilityMedium ?
+                        .system(size: 24, weight: .medium, design: .rounded) :
+                        .title3
+                )
+
             Spacer().frame(width: 10)
+
             Image(systemName: "chevron.up.chevron.down")
+                .font(
+                    sizeCategory >= .accessibilityMedium ?
+                        .system(size: 24, weight: .medium, design: .rounded) :
+                        .body
+                )
         }
-        .font(sizeCategory >= .extraLarge ? .caption : .body)
-        .minimumScaleFactor(0.3)
         .foregroundColor(.red)
         .onTapGesture {
             let haptic = UIImpactFeedbackGenerator(style: .medium)

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoView.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoView.swift
@@ -13,8 +13,6 @@ public struct NextToGoView: View {
 
     @ObservedObject private var viewModel: NextToGoViewModel
 
-    @State private var selectedCountry: String = Country.international.rawValue
-
     @State private var isShowingSettings: Bool = false
 
     private let haptic = UIImpactFeedbackGenerator(style: .medium)
@@ -135,7 +133,8 @@ private extension NextToGoView {
     var headingStack: some View {
         HStack {
             Text(viewModel.title)
-                .font(.title)
+                .font(.title2)
+                .fontWeight(.medium)
                 .foregroundColor(.primary)
                 .multilineTextAlignment(.leading)
                 .accessibilityAddTraits(.isHeader)
@@ -148,9 +147,10 @@ private extension NextToGoView {
 
     @ViewBuilder
     var countrySelectionMenu: some View {
+
         Picker(
             "country:",
-            selection: $selectedCountry
+            selection: $viewModel.selectedCountry
         ) {
             ForEach(viewModel.countries) { country in
                 Text(country.displayName)
@@ -158,11 +158,9 @@ private extension NextToGoView {
                     .foregroundColor(.primary)
             }
         }
+        .id(UUID())
         .pickerStyle(MenuPickerStyle())
         .accentColor(.red)
-        .onChange(of: selectedCountry) { country in
-            viewModel.countrySelectionViewModel.selectedCountry = .init(rawValue: country)
-        }
     }
 }
 

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoView.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoView.swift
@@ -162,8 +162,17 @@ private extension NextToGoView {
             }
         } label: {
             menuLabel(from: "🔝 \(viewModel.selectedTopCount)")
+                .accessibilityLabel(
+                    // TODO: 🤓 move logic into ViewModel, use localised copy and unit test it
+                    "Top \(viewModel.selectedTopCount) races"
+                )
+                .accessibilityAddTraits(.isSelected)
         }
         .menuSelectorStyle()
+        .onTapGesture {
+            let haptic = UIImpactFeedbackGenerator(style: .medium)
+            haptic.impactOccurred()
+        }
     }
 
     @ViewBuilder
@@ -177,20 +186,28 @@ private extension NextToGoView {
         } label: {
             if let country = Country(rawValue: viewModel.selectedCountry) {
                 menuLabel(from: country.shortDisplayName)
+                    .accessibilityLabel(country.name)
+                    .accessibilityAddTraits(.isSelected)
             }
         }
         .menuSelectorStyle()
+        .onTapGesture {
+            let haptic = UIImpactFeedbackGenerator(style: .medium)
+            haptic.impactOccurred()
+        }
     }
 
     @ViewBuilder
     func menuLabel(from title: String) -> some View {
+
         HStack(spacing: 0) {
+
             Text(title)
                 .lineLimit(1)
                 .font(
                     sizeCategory >= .accessibilityMedium ?
                         .system(size: 24, weight: .medium, design: .rounded) :
-                        .title3
+                            .body
                 )
 
             Spacer().frame(width: 10)
@@ -198,15 +215,11 @@ private extension NextToGoView {
             Image(systemName: "chevron.up.chevron.down")
                 .font(
                     sizeCategory >= .accessibilityMedium ?
-                        .system(size: 24, weight: .medium, design: .rounded) :
-                        .body
+                        .system(size: 22, weight: .medium, design: .rounded) :
+                        .subheadline
                 )
         }
         .foregroundColor(.red)
-        .onTapGesture {
-            let haptic = UIImpactFeedbackGenerator(style: .medium)
-            haptic.impactOccurred()
-        }
     }
 
 }

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoView.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoView.swift
@@ -9,12 +9,11 @@ import SharedUtils
 
 public struct NextToGoView: View {
 
-    @State private var selectedCountry = "USA"
-    let countries = ["AUS", "NZ", "USA", "UK"]
-
     // MARK: - Properties
 
     @ObservedObject private var viewModel: NextToGoViewModel
+
+    @State private var selectedCountry: String = Country.international.rawValue
 
     @State private var isShowingSettings: Bool = false
 
@@ -149,15 +148,21 @@ private extension NextToGoView {
 
     @ViewBuilder
     var countrySelectionMenu: some View {
-        Picker("country:", selection: $selectedCountry) {
-            ForEach(countries, id: \.self) { countryCode in
-                Text((CountryUtilities.countryFlag(byAlphaCode: countryCode) ?? "") + " " + countryCode)
+        Picker(
+            "country:",
+            selection: $selectedCountry
+        ) {
+            ForEach(viewModel.countries) { country in
+                Text(country.displayName)
                     .font(.caption)
                     .foregroundColor(.primary)
             }
         }
         .pickerStyle(MenuPickerStyle())
         .accentColor(.red)
+        .onChange(of: selectedCountry) { country in
+            viewModel.countrySelectionViewModel.selectedCountry = .init(rawValue: country)
+        }
     }
 }
 

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoView.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoView.swift
@@ -88,17 +88,17 @@ private extension NextToGoView {
         ToolbarItem(placement: .navigationBarLeading) {
             Button {
                 haptic.impactOccurred()
-                viewModel.loadNextRaces()
+                viewModel.resetFiltersAndRefresh()
             } label: {
-                Image(systemName: viewModel.refreshButtonIcon)
+                Image(systemName: viewModel.resetFiltersIcon)
                     .resizable()
                     .scaledToFit()
                     .font(.system(size: 18, weight: .medium, design: .rounded))
-                    .frame(width: 24, height: 24)
+                    .frame(width: 28, height: 28)
                     .foregroundColor(.primary)
                     .accessibilityAddTraits(.isButton)
-                    .accessibilityLabel(viewModel.refreshButtonTitle)
-                    .accessibilityHint(viewModel.refreshButtonAccessibilityHint)
+                    .accessibilityLabel(viewModel.resetFiltersButtonTitle)
+                    .accessibilityHint(viewModel.resetFiltersButtonAccessibilityHint)
             }
         }
 
@@ -131,7 +131,7 @@ private extension NextToGoView {
                     .resizable()
                     .scaledToFit()
                     .font(.system(size: 18, weight: .medium, design: .rounded))
-                    .frame(width: 24, height: 24)
+                    .frame(width: 28, height: 28)
                     .foregroundColor(.primary)
                     .accessibilityAddTraits(.isButton)
                     .accessibilityLabel(viewModel.settingsButtonTitle)

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoView.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoView.swift
@@ -131,7 +131,7 @@ private extension NextToGoView {
 
     @ViewBuilder
     var headingStack: some View {
-        HStack {
+        VStack(alignment: .leading) {
             Text(viewModel.title)
                 .font(.title2)
                 .fontWeight(.medium)
@@ -139,29 +139,88 @@ private extension NextToGoView {
                 .multilineTextAlignment(.leading)
                 .accessibilityAddTraits(.isHeader)
 
-            Spacer()
-
-            countrySelectionMenu
+            HStack(spacing: 16) {
+                Spacer()
+                topCountSelectionMenu
+                countrySelectionMenu
+            }
         }
     }
 
     @ViewBuilder
-    var countrySelectionMenu: some View {
+    var topCountSelectionMenu: some View {
+        Menu {
+            Picker("", selection: $viewModel.selectedTopCount) {
+                ForEach(viewModel.topCounts, id: \.self) {
+                    Text("\($0)")
+                }
+            }
+        } label: {
+            menuLabel(from: "🔝 \(viewModel.selectedTopCount)")
+        }
+        .menuSelectorStyle()
+    }
 
-        Picker(
-            "country:",
-            selection: $viewModel.selectedCountry
-        ) {
-            ForEach(viewModel.countries) { country in
-                Text(country.displayName)
-                    .font(.caption)
-                    .foregroundColor(.primary)
+    @ViewBuilder
+    var countrySelectionMenu: some View {
+        Menu {
+            Picker("", selection: $viewModel.selectedCountry) {
+                ForEach(viewModel.countries) {
+                    Text($0.fullDisplayName)
+                }
+            }
+        } label: {
+            if let country = Country(rawValue: viewModel.selectedCountry) {
+                menuLabel(from: country.shortDisplayName)
             }
         }
-        .id(UUID())
-        .pickerStyle(MenuPickerStyle())
-        .accentColor(.red)
+        .menuSelectorStyle()
     }
+
+    @ViewBuilder
+    func menuLabel(from title: String) -> some View {
+        HStack(spacing: 0) {
+            Text(title)
+                .font(.body)
+            Spacer().frame(width: 10)
+            Image(systemName: "chevron.up.chevron.down")
+                .font(.body)
+        }
+        .foregroundColor(.red)
+        .onTapGesture {
+            let haptic = UIImpactFeedbackGenerator(style: .medium)
+            haptic.impactOccurred()
+        }
+    }
+
+}
+
+// MARK: - Menu Selector Style
+
+private extension View {
+
+    func menuSelectorStyle() -> some View {
+        self.modifier(MenuSelectorStyle())
+    }
+
+}
+
+private struct MenuSelectorStyle: ViewModifier {
+
+    func body(content: Content) -> some View {
+        content
+            .adaptiveScaleFactor()
+            .padding(.vertical, 8)
+            .padding(.horizontal, 16)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color(UIColor.systemBackground))
+                    .shadow(color: .primary.opacity(0.25), radius: 2, x: 0, y: 0))
+            .contentShape(Rectangle())
+            .accessibilityElement(children: .combine)
+            .accessibilityAddTraits(.isButton)
+    }
+
 }
 
 #if DEBUG

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoView.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoView.swift
@@ -9,6 +9,9 @@ import SharedUtils
 
 public struct NextToGoView: View {
 
+    @State private var selectedCountry = "USA"
+    let countries = ["AUS", "NZ", "USA", "UK"]
+
     // MARK: - Properties
 
     @ObservedObject private var viewModel: NextToGoViewModel
@@ -33,9 +36,16 @@ public struct NextToGoView: View {
 
         NavigationView {
 
-            VStack(alignment: .center, spacing: 10) {
+            VStack(alignment: .center, spacing: 16) {
+
+                headingStack
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 10)
 
                 FiltersView(viewModel: viewModel.filterViewModel)
+                    .padding(.bottom, 10)
+
+                Divider()
 
                 CollectionLoadingView(
                     loadingState: viewModel.loadingState,
@@ -60,9 +70,7 @@ public struct NextToGoView: View {
                     }
                 )
             }
-            .navigationBarTitle(Text(viewModel.title), displayMode: .large)
             .toolbar { toolBarContent }
-            .padding(.top, 20)
         }
         .preferredColorScheme(isDarkMode ? .dark : .light) // link dark / light mode
         .onAppear {
@@ -122,6 +130,34 @@ private extension NextToGoView {
                 SettingsView()
             }
         }
+    }
+
+    @ViewBuilder
+    var headingStack: some View {
+        HStack {
+            Text(viewModel.title)
+                .font(.title)
+                .foregroundColor(.primary)
+                .multilineTextAlignment(.leading)
+                .accessibilityAddTraits(.isHeader)
+
+            Spacer()
+
+            countrySelectionMenu
+        }
+    }
+
+    @ViewBuilder
+    var countrySelectionMenu: some View {
+        Picker("country:", selection: $selectedCountry) {
+            ForEach(countries, id: \.self) { countryCode in
+                Text((CountryUtilities.countryFlag(byAlphaCode: countryCode) ?? "") + " " + countryCode)
+                    .font(.caption)
+                    .foregroundColor(.primary)
+            }
+        }
+        .pickerStyle(MenuPickerStyle())
+        .accentColor(.red)
     }
 }
 

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoViewModel.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoViewModel.swift
@@ -17,11 +17,21 @@ final class NextToGoViewModel: ObservableObject {
 
     @ObservedObject private(set) var filterViewModel: FiltersViewModel
 
+
+    private enum Constants {
+
+        // Choose INTL at start (or default after reset)
+        static let defaultCountry: String = Country.international.rawValue
+
+        // Choose 5 top races at start (or default after reset)
+        static let defaultTopCount: Int = 5
+    }
+
     private(set) var countries: [Country] = Country.allCases
-    @Published var selectedCountry: String = Country.international.rawValue // Choose INTL at start
+    @Published var selectedCountry: String = Constants.defaultCountry
 
     private(set) var topCounts: [Int] = [5, 10, 20, 30]
-    @Published var selectedTopCount: Int = 5 // Choose 5 top races at start
+    @Published var selectedTopCount: Int = Constants.defaultTopCount
 
     // MARK: - Dependency
 
@@ -101,6 +111,16 @@ final class NextToGoViewModel: ObservableObject {
             .assign(to: \.loadingState, on: self)
     }
 
+    func resetFiltersAndRefresh() {
+
+        filterViewModel.resetFilters()
+
+        selectedCountry = Constants.defaultCountry
+        selectedTopCount = Constants.defaultTopCount
+
+        loadNextRaces()
+    }
+
     // MARK: - Computed properties
 
     var title: String {
@@ -111,20 +131,20 @@ final class NextToGoViewModel: ObservableObject {
         "figure.equestrian.sports"
     }
 
-    var refreshButtonIcon: String {
-        "arrow.clockwise.circle"
+    var resetFiltersIcon: String {
+        "slider.horizontal.2.gobackward"
     }
 
-    var refreshButtonTitle: String {
-        "next.togo.races.refresh.button.title".l10n()
+    var resetFiltersButtonTitle: String {
+        "next.togo.races.reset.filters.button.title".l10n()
     }
 
-    var refreshButtonAccessibilityHint: String {
-        "next.togo.races.refresh.button.accessibility.hint".l10n()
+    var resetFiltersButtonAccessibilityHint: String {
+        "next.togo.races.reset.filters.button.accessibility.hint".l10n()
     }
 
     var settingsButtonIcon: String {
-        "slider.horizontal.3"
+        "ellipsis.circle"
     }
 
     var settingsButtonTitle: String {

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoViewModel.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoViewModel.swift
@@ -17,8 +17,7 @@ final class NextToGoViewModel: ObservableObject {
 
     @ObservedObject private(set) var filterViewModel: FiltersViewModel
 
-
-    private enum Constants {
+    enum Constants {
 
         // Choose INTL at start (or default after reset)
         static let defaultCountry: String = Country.international.rawValue

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoViewModel.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/NextToGoViewModel.swift
@@ -210,7 +210,7 @@ enum Country: String, CaseIterable, Identifiable {
 
     var name: String {
         switch self {
-        case .international:    return "INTL"
+        case .international:    return "INTERNATIONAL"
         case .aus:              return "Australia"
         case .nz:               return "New Zealand"
         case .jpn:              return "Japan"
@@ -224,16 +224,20 @@ enum Country: String, CaseIterable, Identifiable {
 
     var fullDisplayName: String {
         if self == .international {
-            return "🌏" + " " + name
+            return internationalName(from: name)
         }
         return (CountryUtilities.countryFlag(byAlphaCode: self.rawValue) ?? "") + " " + name
     }
 
     var shortDisplayName: String {
         if self == .international {
-            return "🌏" + " " + self.rawValue
+            return internationalName(from: self.rawValue)
         }
         return (CountryUtilities.countryFlag(byAlphaCode: self.rawValue) ?? "") + " " + self.rawValue
+    }
+
+    private func internationalName(from name: String) -> String {
+        "🌏" + " " + name
     }
 
 }

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/UIComponents/Filters/FiltersView.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/UIComponents/Filters/FiltersView.swift
@@ -66,10 +66,6 @@ struct FiltersView: View {
             }
         }
         .padding(.horizontal, 10)
-
-        Divider()
-            .padding(.top, 8)
-
     }
 }
 

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/UIComponents/Filters/FiltersView.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/UIComponents/Filters/FiltersView.swift
@@ -31,7 +31,6 @@ struct FiltersView: View {
                     Image(systemName: filter.selected ?
                           "checkmark.circle.fill" : "circle")
                         .font(sizeCategory >= .accessibilityExtraLarge ? .body : .title3)
-                        .scaleEffect(1.1)
                 }
                 .accessibilityElement(children: .combine)
                 .foregroundColor(filter.selected ? .red : .primary)
@@ -50,9 +49,9 @@ struct FiltersView: View {
                     haptic.impactOccurred()
                     viewModel.filterItemTapped(filterItem: filter)
                 }
-                .scaleEffect(filter.selected ? 1.04 : 0.96)
+                .scaleEffect(filter.selected ? 1.05 : 0.95)
                 .animation(
-                    .spring(response: 0.5, dampingFraction: 0.3),
+                    .spring(response: 0.35, dampingFraction: 0.25),
                     value: filter.selected
                 )
                 .accessibilityElement(children: .ignore)

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/UIComponents/Filters/FiltersView.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/UIComponents/Filters/FiltersView.swift
@@ -51,6 +51,11 @@ struct FiltersView: View {
                     haptic.impactOccurred()
                     viewModel.filterItemTapped(filterItem: filter)
                 }
+                .scaleEffect(filter.selected ? 1.04 : 0.96)
+                .animation(
+                    .spring(response: 0.3, dampingFraction: 0.3),
+                    value: filter.selected
+                )
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel(filter.category.accessibilityLabel)
                 .accessibilityHint(

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/UIComponents/Filters/FiltersView.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/UIComponents/Filters/FiltersView.swift
@@ -53,7 +53,7 @@ struct FiltersView: View {
                 }
                 .scaleEffect(filter.selected ? 1.04 : 0.96)
                 .animation(
-                    .spring(response: 0.3, dampingFraction: 0.3),
+                    .spring(response: 0.5, dampingFraction: 0.3),
                     value: filter.selected
                 )
                 .accessibilityElement(children: .ignore)

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/UIComponents/Filters/FiltersView.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/UIComponents/Filters/FiltersView.swift
@@ -11,6 +11,8 @@ struct FiltersView: View {
 
     @StateObject var viewModel: FiltersViewModel
 
+    @Environment(\.sizeCategory) private var sizeCategory
+
     // NOTE: 💗 Test more and find the perfect haptic feelings you need. 💗
     let haptic = UIImpactFeedbackGenerator(style: .heavy)
 
@@ -21,21 +23,18 @@ struct FiltersView: View {
         HStack {
 
             ForEach(viewModel.filters) { filter in
-
-                HStack(spacing: 10) {
-
+                HStack(spacing: 8) {
                     Image(filter.category.iconName, bundle: .module)
-                        .font(.largeTitle)
-                        .scaleEffect(1.4)
+                        .font(sizeCategory >= .accessibilityExtraLarge ? .title : .largeTitle)
+                        .scaleEffect(1.3)
 
                     Image(systemName: filter.selected ?
                           "checkmark.circle.fill" : "circle")
-                        .font(.title3)
+                        .font(sizeCategory >= .accessibilityExtraLarge ? .body : .title3)
                         .scaleEffect(1.1)
                 }
                 .accessibilityElement(children: .combine)
                 .foregroundColor(filter.selected ? .red : .primary)
-                .adaptiveScaleFactor()
                 .padding(.vertical, 6)
                 .padding(.horizontal, 14)
                 .background(

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/UIComponents/Filters/FiltersViewModel.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/UIComponents/Filters/FiltersViewModel.swift
@@ -42,7 +42,7 @@ final class FiltersViewModel: ObservableObject {
 
     // MARK: - Private
 
-    private func resetFilters() {
+    func resetFilters() {
         for item in filters {
             filters[item.id].selected = true
         }

--- a/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/UIComponents/Races/RacesListView.swift
+++ b/PresentationLayer/Sources/PresentationLayer/Features/NextToGo/UIComponents/Races/RacesListView.swift
@@ -78,7 +78,6 @@ struct RaceDetailsView: View {
             Spacer()
         }
         .padding()
-        .adaptiveScaleFactor()
     }
 
 }

--- a/PresentationLayer/Tests/PresentationLayerTests/NextToGoViewModelTests.swift
+++ b/PresentationLayer/Tests/PresentationLayerTests/NextToGoViewModelTests.swift
@@ -36,27 +36,26 @@ final class NextToGoViewModelTests: XCTestCase {
         XCTAssertEqual(testSubject.title, "next.togo.races.title".l10n())
     }
 
-    func testRefreshButtonIconName() {
-        XCTAssertEqual(
-            testSubject.refreshButtonIcon, "arrow.clockwise.circle")
+    func testResetFiltersButtonIconName() {
+        XCTAssertEqual(testSubject.resetFiltersIcon, "slider.horizontal.2.gobackward")
     }
 
-    func testRefreshButtonAccessibilityLabel() {
+    func testResetFiltersButtonAccessibilityLabel() {
         XCTAssertEqual(
-            testSubject.refreshButtonTitle,
-            "next.togo.races.refresh.button.title".l10n()
+            testSubject.resetFiltersButtonTitle,
+            "next.togo.races.reset.filters.button.title".l10n()
         )
     }
 
-    func testRefreshButtonAccessibilityHint() {
+    func testResetFiltersButtonAccessibilityHint() {
         XCTAssertEqual(
-            testSubject.refreshButtonAccessibilityHint,
-            "next.togo.races.refresh.button.accessibility.hint".l10n()
+            testSubject.resetFiltersButtonAccessibilityHint,
+            "next.togo.races.reset.filters.button.accessibility.hint".l10n()
         )
     }
 
     func testSettingsButtonIconName() {
-        XCTAssertEqual(testSubject.settingsButtonIcon, "slider.horizontal.3".l10n())
+        XCTAssertEqual(testSubject.settingsButtonIcon, "ellipsis.circle")
     }
 
     func testSettingsButtonAccessibilityLabel() {


### PR DESCRIPTION
## 🤩 New features 🚀

### 1. 🌎 Country selection filter
AS a punter, I would like `filter out` races `per country` basis from a multiple choices list
SO that I can `focus` where to punt on or go to my `favourite country` races
AND I can re-select back `INTERNATIONAL` to combine all countries again

<img width="300" alt="country-menu" src="https://github.com/arinjoy/next-to-go/assets/7835943/9d3bd5ad-28f7-4628-85c8-32921e169d73">

### 2. 🔝 Top number of races count
AS a punter, I would like to choose how many top number of races to show (ie, 5, 10 or 20)
SO that I can `focus` on the top races only and don't want to see unwanted races
AND I can select this value  from multiple choices list

<img width="350" alt="race-count-menu" src="https://github.com/arinjoy/next-to-go/assets/7835943/4a00c306-92ec-4025-b0ae-a51396f073e6">

## 🤚🏽 Code Changes 🤚🏽

- Add new logic in `Interactor` to take parameter for country code (IINTL means `nil` being passed)
- Pass the country code from VM to interactor to filter on the country
- Create Menu based picker element and custom view modifier for it
- Re-use some of the menu picker style to top races count  menu picker
- Pass the user's selection of top race count to interactor pre-existing count logic
- Update the `refresh button` with `reset button` to clean out all filters,
- Add 🧪 unit test for `Interactor`'s own filtering logic on country and top races count
- Add 🧪 unit test for `ViewModel` to interactor communication about filters selections and reset logic


# Videos & Demo

| Country Selection   |   Top races count Selection  |
|----------|---------|
| ![country-selection](https://github.com/arinjoy/next-to-go/assets/7835943/bb040483-db8d-4f13-8148-542f7b888f80) |  ![top-count-selection](https://github.com/arinjoy/next-to-go/assets/7835943/f245b0db-0d2c-4d74-945a-2dfe521e16a6) | 

| Combined filter effect |   Reset Filters |
|----------|---------|
| ![top-count-county-selection](https://github.com/arinjoy/next-to-go/assets/7835943/aaafc339-cb7f-409e-b044-066528a4a23f) | ![reset-all](https://github.com/arinjoy/next-to-go/assets/7835943/820a1f12-28f8-46ed-89c0-b2651daa145d) | 




